### PR TITLE
fix(admin): 분실물 관리 탭에서 승인된 분실물도 보이는 문제

### DIFF
--- a/src/app/admin-disposal/admin-disposal.hooks.ts
+++ b/src/app/admin-disposal/admin-disposal.hooks.ts
@@ -40,7 +40,7 @@ export const useAdminDisposal = () => {
 
   const buildApiParams = useCallback((): GetItemListParams => {
     const params: GetItemListParams = {
-      status: 'TO_BE_DISCARDED',
+      status: ['TO_BE_DISCARDED'],
       page: currentPage,
       size: 20,
     };

--- a/src/app/disposal-history/disposal-history.hooks.ts
+++ b/src/app/disposal-history/disposal-history.hooks.ts
@@ -21,7 +21,7 @@ export const useDisposalHistory = () => {
 
   const buildApiParams = useCallback((): GetItemListParams => {
     const params: GetItemListParams = {
-      status: 'DISCARDED',
+      status: ['DISCARDED'],
       page: currentPage,
       size: 10,
     };

--- a/src/app/find/detail/[id]/page.tsx
+++ b/src/app/find/detail/[id]/page.tsx
@@ -15,7 +15,7 @@ interface ProductDetailPageProps {
 const ProductDetailPage = ({ params }: ProductDetailPageProps) => {
   const { id } = React.use(params);
   const { data: disposalProductListData } = useItemListQuery({
-    status: 'TO_BE_DISCARDED',
+    status: ['TO_BE_DISCARDED'],
     size: 5,
   });
 

--- a/src/app/find/find.hooks.ts
+++ b/src/app/find/find.hooks.ts
@@ -91,7 +91,7 @@ export const useFindPage = () => {
       const params: GetItemListParams = {
         page: currentPage,
         size: itemsPerPage,
-        status: 'LOST',
+        status: ['LOST'],
       };
 
       if (filters.query) {

--- a/src/app/manage/manage.hooks.ts
+++ b/src/app/manage/manage.hooks.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { formatDateDash } from '@utils/formatDate';
+import { Status } from '@/types/item/client';
 
 export interface Filters {
   search: string;
@@ -7,6 +8,7 @@ export interface Filters {
   startDate: Date | null;
   endDate: Date | null;
   placeIds: string[];
+  status: Status[];
 }
 
 export const useForm = () => {
@@ -16,6 +18,7 @@ export const useForm = () => {
     startDate: null,
     endDate: null,
     placeIds: [],
+    status: ['LOST', 'DISCARDED', 'TO_BE_DISCARDED'],
   });
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -50,6 +53,7 @@ export const useForm = () => {
       ? formatDateDash(filters.startDate)
       : undefined,
     foundAtTo: filters.endDate ? formatDateDash(filters.endDate) : undefined,
+    status: filters.status,
   });
 
   return {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ const MainPage = () => {
   const router = useRouter();
   const { authority, isLoggedIn } = useAuthStore();
   const { data: disposalProductListData } = useItemListQuery({
-    status: 'TO_BE_DISCARDED',
+    status: ['TO_BE_DISCARDED'],
     size: 5,
   });
   const { data: recallProductListData } = useClaimItemListQuery();

--- a/src/components/common/ProductList/ProductListItem/ProductListItem.tsx
+++ b/src/components/common/ProductList/ProductListItem/ProductListItem.tsx
@@ -195,7 +195,7 @@ const InfoSection = styled.div`
 
 const statusColor = {
   LOST: '#14C600',
-  FOUND: '#FFCC00',
+  GIVEN: '#FFCC00',
   TO_BE_DISCARDED: '#FF883E',
   DISCARDED: '#FF2727',
 };

--- a/src/components/disposal/DisposalTable/DisposalTable.tsx
+++ b/src/components/disposal/DisposalTable/DisposalTable.tsx
@@ -47,7 +47,7 @@ const DisposalTable = ({ filters }: DisposalTableProps) => {
   }, [filters]);
 
   const { data } = useDisposalItemsQuery({
-    status: 'TO_BE_DISCARDED',
+    status: ['TO_BE_DISCARDED'],
     page: currentPage,
     size: ITEMS_PER_PAGE,
     ...filters,

--- a/src/constants/item/constant.ts
+++ b/src/constants/item/constant.ts
@@ -1,6 +1,6 @@
 export const STATUS = {
   LOST: '보관중',
-  FOUND: '지급 완료',
+  GIVEN: '지급 완료',
   TO_BE_DISCARDED: '폐기 예정',
   DISCARDED: '폐기 완료',
 };

--- a/src/services/disposal/queries.ts
+++ b/src/services/disposal/queries.ts
@@ -16,7 +16,7 @@ export const useDisposalItemsCountQuery = () => {
     queryKey: ['disposal', 'items', 'count'],
     queryFn: () =>
       getDisposalItems({
-        status: 'TO_BE_DISCARDED',
+        status: ['TO_BE_DISCARDED'],
         page: 1,
         size: 1,
       }),
@@ -31,7 +31,7 @@ export const useImminentDisposalQuery = () => {
     queryKey: ['disposal', 'imminent'],
     queryFn: () =>
       getDisposalItems({
-        status: 'TO_BE_DISCARDED',
+        status: ['TO_BE_DISCARDED'],
         page: 1,
         size: 3,
       }),

--- a/src/types/item/client.ts
+++ b/src/types/item/client.ts
@@ -1,6 +1,6 @@
 import { CATEGORY } from '@/constants/item/constant';
 
-export type Status = 'LOST' | 'FOUND' | 'TO_BE_DISCARDED' | 'DISCARDED';
+export type Status = 'LOST' | 'GIVEN' | 'TO_BE_DISCARDED' | 'DISCARDED';
 export type ApprovalStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 
 export type Category = (typeof CATEGORY)[number] | '';

--- a/src/types/item/params.ts
+++ b/src/types/item/params.ts
@@ -3,7 +3,7 @@ import { ItemForm, Status } from './client';
 export interface GetItemListParams {
   page?: number;
   size?: number;
-  status?: Status;
+  status?: Status[];
   categories?: string[];
   placeIds?: number[];
   foundAtFrom?: string;


### PR DESCRIPTION
## 📄 Summary

> 분실물 관리 탭에서 승인된 분실물도 보이는 문제

<br>

## 🔨 Tasks

- status 필터를 추가하여 GIVEN은 제외시킴

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 상태 이름을 "지급 완료"로 변경하여 명확성 개선

* **새로운 기능**
  * 여러 상태를 동시에 필터링할 수 있도록 필터링 시스템 개선
  * 관리 인터페이스에서 상태 기반 필터 추가 (손실, 지급 완료, 폐기 대기, 폐기 완료 포함)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->