### PR TITLE
feat(common): 버튼 재스타일링 & color primary, secondary 100-500 추가

### DIFF
--- a/src/app/admin-disposal/page.tsx
+++ b/src/app/admin-disposal/page.tsx
@@ -159,7 +159,7 @@ const FilterTag = styled.div`
   gap: 8px;
   height: 38px;
   padding: 0 16px;
-  background-color: ${color.secondary};
+  background-color: ${color.secondary300};
   color: ${color.white};
   border-radius: 20px;
   font-family: 'Pretendard', sans-serif;

--- a/src/app/disposal-history/page.tsx
+++ b/src/app/disposal-history/page.tsx
@@ -150,7 +150,7 @@ const FilterTag = styled.div`
   gap: 8px;
   height: 38px;
   padding: 0 16px;
-  background-color: ${color.secondary};
+  background-color: ${color.secondary300};
   color: ${color.white};
   border-radius: 20px;
   font-family: 'Pretendard', sans-serif;

--- a/src/app/find/page.tsx
+++ b/src/app/find/page.tsx
@@ -142,7 +142,7 @@ const FilterTag = styled.div`
   gap: 8px;
   height: 38px;
   padding: 0 16px;
-  background-color: ${color.primary};
+  background-color: ${color.primary300};
   color: ${color.white};
   border-radius: 20px;
   font-family: 'Pretendard', sans-serif;

--- a/src/app/markdown/page.tsx
+++ b/src/app/markdown/page.tsx
@@ -38,7 +38,7 @@ const MarkdownPage = () => {
           <div>불러오는중...</div>
         )}
       </EditorContainer>
-      <Button styleType="GHOST" onClick={handleMarkdownSubmit}>
+      <Button styleType="SECONDARY" onClick={handleMarkdownSubmit}>
         저장하기
       </Button>
     </StyledMarkdownPage>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,12 +62,11 @@ const MainPage = () => {
               어디
             </Text>
             <Button
-              styleType={'SECONDARY'}
+              styleType="SECONDARY"
               onClick={() => router.push(ROUTES.RULES)}
+              size="big"
             >
-              <Text variant="H4" color={color.white}>
-                상벌점제 규정 확인하기
-              </Text>
+              상벌점제 규정 확인하기
             </Button>
           </Flex>
         )}

--- a/src/components/admin-disposal/ExtensionModal/ExtensionModal.tsx
+++ b/src/components/admin-disposal/ExtensionModal/ExtensionModal.tsx
@@ -178,17 +178,18 @@ const ExtensionModal = ({
 
           <Flex gap={8} justify="center">
             <Button
-              styleType="GHOST_SECONDARY"
-              size="modal"
+              styleType="SECONDARY"
+              size="small"
               onClick={handleClose}
+              outlined
             >
               <IconClose width={24} height={24} color={color.secondary} />
               <Text variant="p2" color={color.secondary}>
-                {'취소'}
+                취소
               </Text>
             </Button>
 
-            <Button styleType="SECONDARY" size="modal" onClick={handleConfirm}>
+            <Button styleType="SECONDARY" size="small" onClick={handleConfirm}>
               <IconCheck width={24} height={24} color={color.white} />
               <Text variant="p2" color={color.white}>
                 연장

--- a/src/components/admin-disposal/ExtensionModal/ExtensionModal.tsx
+++ b/src/components/admin-disposal/ExtensionModal/ExtensionModal.tsx
@@ -183,8 +183,8 @@ const ExtensionModal = ({
               onClick={handleClose}
               outlined
             >
-              <IconClose width={24} height={24} color={color.secondary} />
-              <Text variant="p2" color={color.secondary}>
+              <IconClose width={24} height={24} color={color.secondary300} />
+              <Text variant="p2" color={color.secondary300}>
                 취소
               </Text>
             </Button>
@@ -271,7 +271,7 @@ const ModalTextarea = styled.textarea`
 
   &:focus {
     outline: none;
-    border-color: ${color.secondary};
+    border-color: ${color.secondary300};
   }
 `;
 

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -84,6 +84,10 @@ const resolveColorStyle = (
         border-color: ${colors.disabled};
         color: ${colors.disabled};
         background-color: ${color.white};
+
+        svg {
+          fill: ${colors.disabled};
+        }
       }
 
       svg {

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -1,137 +1,73 @@
 import { css } from '@emotion/react';
 import color from '@styles/color';
 import font from '@styles/font';
-import { ButtonSize } from './Button.type';
+import { ButtonSize, ButtonStyleType } from './Button.type';
 
-const getSizeStyle = (size: ButtonSize) => {
-  switch (size) {
-    case 'medium':
-      return css`
-        padding: 10px 20px;
-        ${font.p2};
-      `;
-    case 'small':
-      return css`
-        padding: 2px 8px;
-        ${font.p3};
-      `;
-    case 'modal':
-      return css`
-        padding: 2px 8px;
-        ${font.p2};
-      `;
-    case 'compact':
-      return css`
-        padding: 5px 20px;
-        ${font.p2};
-      `;
-    default:
-      return css`
-        padding: 10px 20px;
-        ${font.p2};
-      `;
-  }
+const COLOR_MAP = {
+  PRIMARY: color.primary,
+  SECONDARY: color.secondary,
 };
 
-export const getButtonStyle = {
-  PRIMARY: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${outlined ? color.white : color.primary};
-    color: ${outlined ? color.primary : color.white};
-    border: ${outlined ? `1.5px solid ${color.primary}` : 'none'};
-    ${getSizeStyle(size)};
+const SIZE_MAP = {
+  small: {
+    defaultPad: '0 8px',
+    iconPad: '0 2px',
+    typography: font.p3,
+    height: '24px',
+  },
+  medium: {
+    defaultPad: '0 12px',
+    iconPad: '0 4px',
+    typography: font.p2,
+    height: '32px',
+  },
+  big: {
+    defaultPad: '0 16px',
+    iconPad: '0 6px',
+    typography: font.H3,
+    height: '40px',
+  },
+};
 
-    svg {
-      fill: ${outlined ? color.primary : color.white};
-    }
+const resolvePadding = (
+  defaultPad: string,
+  iconPad: string,
+  hasIcon: boolean,
+  hasText: boolean
+): string => {
+  if (hasIcon && hasText) return `${defaultPad} ${iconPad}`;
+  if (hasIcon) return iconPad;
+  return defaultPad;
+};
 
-    &:hover {
-      background-color: ${color.primary};
-      color: ${color.white};
+const resolveColorStyle = (mainColor: string, outlined: boolean) =>
+  outlined
+    ? css`
+        border: 1px solid ${mainColor};
+        background-color: ${color.white};
+        color: ${mainColor};
+      `
+    : css`
+        background-color: ${mainColor};
+        color: ${color.white};
+      `;
 
-      svg {
-        fill: ${color.white};
-      }
-    }
-  `,
-  SECONDARY: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${outlined ? color.white : color.secondary};
-    color: ${outlined ? color.secondary : color.white};
-    border: ${outlined ? `1.5px solid ${color.secondary}` : 'none'};
-    ${getSizeStyle(size)};
+export const getButtonStyle = (
+  styleType: ButtonStyleType,
+  outlined: boolean,
+  size: ButtonSize,
+  hasIcon: boolean,
+  hasText: boolean
+) => {
+  const mainColor = COLOR_MAP[styleType];
+  const { defaultPad, iconPad, typography, height } = SIZE_MAP[size];
+  const padding = resolvePadding(defaultPad, iconPad, hasIcon, hasText);
+  const colorStyle = resolveColorStyle(mainColor, outlined);
 
-    svg {
-      fill: ${outlined ? color.secondary : color.white};
-    }
-
-    &:hover {
-      background-color: ${color.secondary};
-      color: ${color.white};
-
-      svg {
-        fill: ${color.white};
-      }
-    }
-  `,
-  TERTIARY: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${color.white};
-    color: ${color.black};
-    ${getSizeStyle(size)};
-    &:hover {
-      background-color: ${color.gray100};
-    }
-  `,
-  GHOST: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${color.white};
-    color: ${color.black};
-    ${getSizeStyle(size)};
-    border: 0.5px solid ${color.gray200};
-
-    &:hover {
-      background-color: ${color.gray100};
-    }
-  `,
-  GHOST_SECONDARY: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${color.white};
-    color: ${color.secondary};
-    ${getSizeStyle(size)};
-    border: 1px solid ${color.secondary};
-
-    svg {
-      fill: ${color.secondary};
-    }
-
-    &:hover {
-      background-color: ${color.gray100};
-    }
-  `,
-  GHOST_DANGER: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${color.white};
-    color: ${color.red};
-    ${getSizeStyle(size)};
-    border: 1px solid ${color.red};
-
-    svg {
-      fill: ${color.red};
-    }
-
-    &:hover {
-      background-color: ${color.red};
-      color: ${color.white};
-      border-color: ${color.red};
-
-      svg {
-        fill: ${color.white};
-      }
-    }
-  `,
-  DANGER: (outlined: boolean, size: ButtonSize) => css`
-    background-color: ${color.red};
-    color: ${color.white};
-    ${getSizeStyle(size)};
-    border: 1px solid ${color.red};
-
-    svg {
-      fill: ${color.white};
-    }
-  `,
+  return css`
+    height: ${height};
+    padding: ${padding};
+    ${typography};
+    ${colorStyle};
+  `;
 };

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -4,8 +4,22 @@ import font from '@styles/font';
 import { ButtonSize, ButtonStyleType } from './Button.type';
 
 const COLOR_MAP = {
-  PRIMARY: color.primary300,
-  SECONDARY: color.secondary300,
+  PRIMARY: {
+    default: color.primary300,
+    disabled: color.primary200,
+    hover: color.primary400,
+    clicked: color.primary500,
+    hoverBg: color.primary100,
+    clickedBg: color.primary200,
+  },
+  SECONDARY: {
+    default: color.secondary300,
+    disabled: color.secondary200,
+    hover: color.secondary400,
+    clicked: color.secondary500,
+    hoverBg: color.secondary100,
+    clickedBg: color.secondary200,
+  },
 };
 
 const SIZE_MAP = {
@@ -40,18 +54,45 @@ const resolvePadding = (
   return defaultPad;
 };
 
-const resolveColorStyle = (mainColor: string, outlined: boolean) =>
-  outlined
-    ? css`
-        border: 1.5px solid ${mainColor};
-        background-color: ${color.white};
-        color: ${mainColor};
-      `
-    : css`
-        background-color: ${mainColor};
-        color: ${color.white};
-      `;
+const resolveColorStyle = (
+  colors: (typeof COLOR_MAP)[keyof typeof COLOR_MAP],
+  outlined: boolean
+) => {
+  if (outlined) {
+    return css`
+      border: 1.5px solid ${colors.default};
+      background-color: ${color.white};
+      color: ${colors.default};
 
+      &:hover {
+        background-color: ${colors.hoverBg};
+      }
+      &:active {
+        background-color: ${colors.clickedBg};
+      }
+      &:disabled {
+        border-color: ${colors.disabled};
+        color: ${colors.disabled};
+        background-color: ${color.white};
+      }
+    `;
+  }
+
+  return css`
+    background-color: ${colors.default};
+    color: ${color.white};
+
+    &:hover {
+      background-color: ${colors.hover};
+    }
+    &:active {
+      background-color: ${colors.clicked};
+    }
+    &:disabled {
+      background-color: ${colors.disabled};
+    }
+  `;
+};
 export const getButtonStyle = (
   styleType: ButtonStyleType,
   outlined: boolean,
@@ -59,10 +100,10 @@ export const getButtonStyle = (
   hasIcon: boolean,
   hasText: boolean
 ) => {
-  const mainColor = COLOR_MAP[styleType];
+  const colors = COLOR_MAP[styleType];
   const { defaultPad, iconPad, typography, height } = SIZE_MAP[size];
   const padding = resolvePadding(defaultPad, iconPad, hasIcon, hasText);
-  const colorStyle = resolveColorStyle(mainColor, outlined);
+  const colorStyle = resolveColorStyle(colors, outlined);
 
   return css`
     height: ${height};

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -10,22 +10,22 @@ const COLOR_MAP = {
 
 const SIZE_MAP = {
   small: {
-    defaultPad: '0 8px',
-    iconPad: '0 2px',
-    typography: font.p3,
-    height: '24px',
-  },
-  medium: {
     defaultPad: '0 12px',
     iconPad: '0 4px',
     typography: font.p2,
     height: '32px',
   },
-  big: {
+  medium: {
     defaultPad: '0 16px',
     iconPad: '0 6px',
     typography: font.H3,
     height: '40px',
+  },
+  big: {
+    defaultPad: '0 20px',
+    iconPad: '0 8px',
+    typography: font.H2,
+    height: '44px',
   },
 };
 

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -4,8 +4,8 @@ import font from '@styles/font';
 import { ButtonSize, ButtonStyleType } from './Button.type';
 
 const COLOR_MAP = {
-  PRIMARY: color.primary,
-  SECONDARY: color.secondary,
+  PRIMARY: color.primary300,
+  SECONDARY: color.secondary300,
 };
 
 const SIZE_MAP = {

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -64,13 +64,15 @@ const resolvePadding = (
 
 const resolveColorStyle = (
   colors: (typeof COLOR_MAP)[keyof typeof COLOR_MAP],
-  outlined: boolean
+  outlined: boolean,
+  active: boolean
 ) => {
   if (outlined) {
     return css`
       border: 1.5px solid ${colors.default};
       background-color: ${color.white};
       color: ${colors.default};
+      ${active && `background-color: ${colors.outlined.clicked};`}
 
       &:hover {
         background-color: ${colors.outlined.hover};
@@ -89,6 +91,7 @@ const resolveColorStyle = (
   return css`
     background-color: ${colors.default};
     color: ${color.white};
+    ${active && `background-color: ${colors.filled.clicked};`}
 
     &:hover {
       background-color: ${colors.filled.hover};
@@ -106,12 +109,13 @@ export const getButtonStyle = (
   outlined: boolean,
   size: ButtonSize,
   hasIcon: boolean,
-  hasText: boolean
+  hasText: boolean,
+  active: boolean
 ) => {
   const colors = COLOR_MAP[styleType];
   const { defaultPad, iconPad, typography, height } = SIZE_MAP[size];
   const padding = resolvePadding(defaultPad, iconPad, hasIcon, hasText);
-  const colorStyle = resolveColorStyle(colors, outlined);
+  const colorStyle = resolveColorStyle(colors, outlined, active);
 
   return css`
     height: ${height};

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -11,20 +11,20 @@ const COLOR_MAP = {
 const SIZE_MAP = {
   small: {
     defaultPad: '0 12px',
-    iconPad: '0 4px',
-    typography: font.p2,
+    iconPad: '0 8px',
+    typography: font.p3,
     height: '32px',
   },
   medium: {
     defaultPad: '0 16px',
-    iconPad: '0 6px',
-    typography: font.H3,
+    iconPad: '0 8px',
+    typography: font.p2,
     height: '40px',
   },
   big: {
     defaultPad: '0 20px',
-    iconPad: '0 8px',
-    typography: font.H2,
+    iconPad: '0 10px',
+    typography: font.H4,
     height: '44px',
   },
 };
@@ -43,7 +43,7 @@ const resolvePadding = (
 const resolveColorStyle = (mainColor: string, outlined: boolean) =>
   outlined
     ? css`
-        border: 1px solid ${mainColor};
+        border: 1.5px solid ${mainColor};
         background-color: ${color.white};
         color: ${mainColor};
       `

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -75,7 +75,7 @@ const resolveColorStyle = (
       ${active && `background-color: ${colors.outlined.clicked};`}
 
       &:hover {
-        background-color: ${colors.outlined.hover};
+        ${!active && `background-color: ${colors.outlined.hover}`};
       }
       &:active {
         background-color: ${colors.outlined.clicked};
@@ -84,6 +84,10 @@ const resolveColorStyle = (
         border-color: ${colors.disabled};
         color: ${colors.disabled};
         background-color: ${color.white};
+      }
+
+      svg {
+        fill: ${colors.default};
       }
     `;
   }
@@ -94,13 +98,17 @@ const resolveColorStyle = (
     ${active && `background-color: ${colors.filled.clicked};`}
 
     &:hover {
-      background-color: ${colors.filled.hover};
+      ${!active && `background-color: ${colors.filled.hover}`}
     }
     &:active {
       background-color: ${colors.filled.clicked};
     }
     &:disabled {
       background-color: ${colors.disabled};
+    }
+
+    svg {
+      fill: ${color.white};
     }
   `;
 };

--- a/src/components/common/Button/Button.style.ts
+++ b/src/components/common/Button/Button.style.ts
@@ -7,18 +7,26 @@ const COLOR_MAP = {
   PRIMARY: {
     default: color.primary300,
     disabled: color.primary200,
-    hover: color.primary400,
-    clicked: color.primary500,
-    hoverBg: color.primary100,
-    clickedBg: color.primary200,
+    filled: {
+      hover: color.primary400,
+      clicked: color.primary500,
+    },
+    outlined: {
+      hover: color.primary100,
+      clicked: color.primary200,
+    },
   },
   SECONDARY: {
     default: color.secondary300,
     disabled: color.secondary200,
-    hover: color.secondary400,
-    clicked: color.secondary500,
-    hoverBg: color.secondary100,
-    clickedBg: color.secondary200,
+    filled: {
+      hover: color.secondary400,
+      clicked: color.secondary500,
+    },
+    outlined: {
+      hover: color.secondary100,
+      clicked: color.secondary200,
+    },
   },
 };
 
@@ -65,10 +73,10 @@ const resolveColorStyle = (
       color: ${colors.default};
 
       &:hover {
-        background-color: ${colors.hoverBg};
+        background-color: ${colors.outlined.hover};
       }
       &:active {
-        background-color: ${colors.clickedBg};
+        background-color: ${colors.outlined.clicked};
       }
       &:disabled {
         border-color: ${colors.disabled};
@@ -83,10 +91,10 @@ const resolveColorStyle = (
     color: ${color.white};
 
     &:hover {
-      background-color: ${colors.hover};
+      background-color: ${colors.filled.hover};
     }
     &:active {
-      background-color: ${colors.clicked};
+      background-color: ${colors.filled.clicked};
     }
     &:disabled {
       background-color: ${colors.disabled};

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -46,16 +46,20 @@ export const Button = ({
     justify-content: center;
     border-radius: 8px;
     border: none;
-    cursor: pointer;
     transition: all 0.2s ease-in-out;
     white-space: nowrap;
     width: ${widthValue};
+
+    &:disabled {
+      cursor: not-allowed;
+    }
 
     ${getButtonStyle(styleType, outlined, size, hasIcon, hasText)}
   `;
 
   return (
-    <button css={baseStyle} {...restProps}>
+    <button css={baseStyle} {...restProps} disabled={disabled}>
+      {icon}
       {children}
     </button>
   );

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,29 +1,29 @@
 import { css } from '@emotion/react';
-import type { ButtonHTMLAttributes, CSSProperties } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import { getButtonStyle } from './Button.style';
 import type { ButtonSize, ButtonStyleType } from './Button.type';
+import { addPX } from '@/utils';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   styleType?: ButtonStyleType;
   size?: ButtonSize;
   outlined?: boolean;
-  width?: CSSProperties['width'];
-  height?: CSSProperties['height'];
+  width?: number | string;
+  height?: number | string;
 }
 
-export const Button = (props: ButtonProps) => {
-  const {
-    styleType = 'PRIMARY',
-    size = 'medium',
-    outlined = false,
-    width = 'auto',
-    height = 'auto',
-    children,
-    ...restProps
-  } = props;
-
-  const widthValue = typeof width === 'number' ? `${width}px` : width;
-  const heightValue = typeof height === 'number' ? `${height}px` : height;
+export const Button = ({
+  styleType = 'PRIMARY',
+  size = 'medium',
+  outlined = false,
+  width = 'auto',
+  height = 'auto',
+  disabled = false,
+  children,
+  ...restProps
+}: ButtonProps) => {
+  const widthValue = addPX(width);
+  const heightValue = addPX(height);
 
   const baseStyle = css`
     box-sizing: border-box;

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -10,7 +10,6 @@ interface ButtonBaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   outlined?: boolean;
   disabled?: boolean;
   width?: number | string;
-  height?: number | string;
   active?: boolean;
 }
 

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonBaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
   width?: number | string;
   height?: number | string;
+  active?: boolean;
 }
 
 type ButtonProps = ButtonBaseProps &
@@ -32,6 +33,7 @@ export const Button = ({
   width = 'auto',
   disabled = false,
   icon,
+  active = false,
   children,
   ...restProps
 }: ButtonProps) => {
@@ -54,7 +56,7 @@ export const Button = ({
       cursor: not-allowed;
     }
 
-    ${getButtonStyle(styleType, outlined, size, hasIcon, hasText)}
+    ${getButtonStyle(styleType, outlined, size, hasIcon, hasText, active)}
   `;
 
   return (

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -4,26 +4,40 @@ import { getButtonStyle } from './Button.style';
 import type { ButtonSize, ButtonStyleType } from './Button.type';
 import { addPX } from '@/utils';
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonBaseProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   styleType?: ButtonStyleType;
   size?: ButtonSize;
   outlined?: boolean;
+  disabled?: boolean;
   width?: number | string;
   height?: number | string;
 }
+
+type ButtonProps = ButtonBaseProps &
+  (
+    | {
+        icon: React.ReactNode;
+        children?: React.ReactNode;
+      }
+    | {
+        icon?: undefined;
+        children: React.ReactNode;
+      }
+  );
 
 export const Button = ({
   styleType = 'PRIMARY',
   size = 'medium',
   outlined = false,
   width = 'auto',
-  height = 'auto',
   disabled = false,
+  icon,
   children,
   ...restProps
 }: ButtonProps) => {
   const widthValue = addPX(width);
-  const heightValue = addPX(height);
+  const hasIcon = !!icon;
+  const hasText = !!children;
 
   const baseStyle = css`
     box-sizing: border-box;
@@ -36,9 +50,8 @@ export const Button = ({
     transition: all 0.2s ease-in-out;
     white-space: nowrap;
     width: ${widthValue};
-    height: ${heightValue};
 
-    ${getButtonStyle[styleType](outlined, size)}
+    ${getButtonStyle(styleType, outlined, size, hasIcon, hasText)}
   `;
 
   return (

--- a/src/components/common/Button/Button.type.ts
+++ b/src/components/common/Button/Button.type.ts
@@ -1,9 +1,3 @@
-export type ButtonStyleType =
-  | 'PRIMARY'
-  | 'SECONDARY'
-  | 'TERTIARY'
-  | 'GHOST'
-  | 'GHOST_SECONDARY'
-  | 'GHOST_DANGER'
-  | 'DANGER';
-export type ButtonSize = 'medium' | 'small' | 'modal' | 'compact';
+export type ButtonStyleType = 'PRIMARY' | 'SECONDARY';
+
+export type ButtonSize = 'big' | 'medium' | 'small';

--- a/src/components/common/DateSelector/DateSelector.styles.ts
+++ b/src/components/common/DateSelector/DateSelector.styles.ts
@@ -37,7 +37,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
   }
 
   .react-datepicker__navigation-icon::before {
-    border-color: ${color.primary};
+    border-color: ${color.primary300};
     border-width: 2.5px 2.5px 0 0;
     border-radius: 2px;
   }
@@ -95,7 +95,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
 
   .react-datepicker__day--in-range {
     font-weight: 700;
-    background-color: ${color.lightblue} !important;
+    background-color: ${color.primary100} !important;
     color: ${color.black} !important;
     border-radius: 0 !important;
   }
@@ -117,7 +117,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
     right: 0;
     width: 50%;
     height: 100%;
-    background-color: ${color.lightblue};
+    background-color: ${color.primary100};
     z-index: 0;
   }
 
@@ -130,7 +130,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
     left: 0;
     width: 50%;
     height: 100%;
-    background-color: ${color.lightblue};
+    background-color: ${color.primary100};
     z-index: 0;
   }
 
@@ -141,7 +141,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: ${color.primary};
+    background-color: ${color.primary300};
     border-radius: 50%;
     z-index: 1;
   }
@@ -153,7 +153,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: ${color.primary};
+    background-color: ${color.primary300};
     border-radius: 50%;
     z-index: 1;
   }
@@ -165,7 +165,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
 
   .react-datepicker__day--range-start.react-datepicker__day--range-end {
     &::after {
-      background-color: ${color.primary};
+      background-color: ${color.primary300};
       border-radius: 50%;
       width: 100%;
       left: 0;
@@ -178,7 +178,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
   }
 
   .react-datepicker__day--in-selecting-range {
-    background-color: ${color.lightblue} !important;
+    background-color: ${color.primary100} !important;
     color: ${color.black} !important;
     border-radius: 0 !important;
   }
@@ -199,7 +199,7 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
   }
 
   .react-datepicker__day--selected {
-    background-color: ${color.primary} !important;
+    background-color: ${color.primary300} !important;
     color: ${color.white} !important;
     border-radius: 20px !important;
     font-weight: 700;
@@ -215,6 +215,6 @@ export const StyledDateSelector = styled.div<{ width: string | number }>`
 
   .react-datepicker__day--today {
     font-weight: 700;
-    color: ${color.primary};
+    color: ${color.primary300};
   }
 `;

--- a/src/components/common/Dropdown/Dropdown.tsx
+++ b/src/components/common/Dropdown/Dropdown.tsx
@@ -106,7 +106,7 @@ const StyledDropdown = styled.div<{
     }
     if ($isOpen && !$disabled) {
       return css`
-        border: 1px solid ${color.primary};
+        border: 1px solid ${color.primary300};
         outline: 2px solid rgba(135, 206, 235, 0.25);
       `;
     }
@@ -163,7 +163,7 @@ const DropdownItem = styled.button<{ $isSelected: boolean }>`
   width: 100%;
   text-align: left;
   background-color: ${({ $isSelected }) =>
-    $isSelected ? color.lightblue : 'transparent'};
+    $isSelected ? color.primary100 : 'transparent'};
   color: ${color.black};
   font-weight: ${({ $isSelected }) => ($isSelected ? 600 : 400)};
   border: none;
@@ -171,6 +171,6 @@ const DropdownItem = styled.button<{ $isSelected: boolean }>`
   transition: background-color 0.15s ease;
 
   &:hover {
-    background-color: ${color.lightblue};
+    background-color: ${color.primary100};
   }
 `;

--- a/src/components/common/Dropdown/InputDropdown.tsx
+++ b/src/components/common/Dropdown/InputDropdown.tsx
@@ -108,7 +108,7 @@ const StyledDropdown = styled.div<{
     }
     if ($isOpen && !$disabled) {
       return css`
-        border: 1px solid ${color.primary};
+        border: 1px solid ${color.primary300};
         outline: 2px solid rgba(135, 206, 235, 0.25);
       `;
     }
@@ -167,7 +167,7 @@ const DropdownItem = styled.button<{ $isSelected: boolean }>`
   width: 100%;
   text-align: center;
   background-color: ${({ $isSelected }) =>
-    $isSelected ? color.lightblue : 'transparent'};
+    $isSelected ? color.primary100 : 'transparent'};
   color: ${color.black};
   font-weight: 300;
   border: none;
@@ -176,6 +176,6 @@ const DropdownItem = styled.button<{ $isSelected: boolean }>`
   min-height: 34px;
 
   &:hover {
-    background-color: ${color.lightblue};
+    background-color: ${color.primary100};
   }
 `;

--- a/src/components/common/Dropdown/MultiSelectDropdown.tsx
+++ b/src/components/common/Dropdown/MultiSelectDropdown.tsx
@@ -143,7 +143,7 @@ const StyledDropdown = styled.div<{
   ${({ $isOpen, $disabled }) => {
     if ($isOpen && !$disabled) {
       return css`
-        border: 1px solid ${color.primary};
+        border: 1px solid ${color.primary300};
         outline: 2px solid rgba(135, 206, 235, 0.25);
       `;
     }
@@ -224,7 +224,7 @@ const CheckboxLabel = styled.span`
 const ApplyButton = styled.button`
   align-self: flex-end;
   padding: 4px 36px;
-  background-color: ${color.secondary};
+  background-color: ${color.secondary300};
   color: ${color.white};
   border: none;
   border-radius: 8px;

--- a/src/components/common/Filter/FilterActiveTags/FilterActiveTags.tsx
+++ b/src/components/common/Filter/FilterActiveTags/FilterActiveTags.tsx
@@ -38,7 +38,7 @@ const FilterTag = styled.div`
   gap: 8px;
   height: 38px;
   padding: 0 16px;
-  background-color: ${color.secondary};
+  background-color: ${color.secondary300};
   color: ${color.white};
   border-radius: 20px;
 

--- a/src/components/common/Filter/FilterDateSelect/FilterDateCustomInput/FilterDateCustomInput.tsx
+++ b/src/components/common/Filter/FilterDateSelect/FilterDateCustomInput/FilterDateCustomInput.tsx
@@ -46,7 +46,7 @@ const DateButton = styled.button<{ $hasValue: boolean; $isOpen: boolean }>`
   padding: 0 16px;
   background-color: ${color.white};
   border: 1px solid
-    ${({ $isOpen }) => ($isOpen ? color.primary : color.gray300)};
+    ${({ $isOpen }) => ($isOpen ? color.primary300 : color.gray300)};
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -57,7 +57,7 @@ const DateButton = styled.button<{ $hasValue: boolean; $isOpen: boolean }>`
   }
 
   &:hover {
-    border-color: ${color.primary};
+    border-color: ${color.primary300};
   }
 `;
 

--- a/src/components/common/Header/NavItemList/NavItemList.tsx
+++ b/src/components/common/Header/NavItemList/NavItemList.tsx
@@ -35,12 +35,12 @@ export const NavItemList = () => {
         분실물 등록 하기
       </Button>
       {isLoggedIn ? (
-        <Button styleType={'GHOST'} onClick={() => handleLogout()}>
+        <Button styleType="PRIMARY" onClick={() => handleLogout()} outlined>
           로그아웃
         </Button>
       ) : (
-        <Button styleType={'PRIMARY'} onClick={() => handleLogin()}>
-          로그인
+        <Button styleType="PRIMARY" onClick={() => handleLogin()}>
+          bsm 로그인
         </Button>
       )}
     </StyledNavItemsList>
@@ -56,12 +56,12 @@ export const NavItemList = () => {
         폐기 항목 보기
       </NavItem>
       {isLoggedIn ? (
-        <Button styleType={'GHOST'} onClick={() => handleLogout()}>
+        <Button styleType="PRIMARY" onClick={() => handleLogout()} outlined>
           로그아웃
         </Button>
       ) : (
-        <Button styleType={'PRIMARY'} onClick={() => handleLogin()}>
-          로그인
+        <Button styleType="PRIMARY" onClick={() => handleLogin()}>
+          bsm 로그인
         </Button>
       )}
     </StyledNavItemsList>
@@ -71,12 +71,12 @@ export const NavItemList = () => {
     <StyledNavItemsList>
       <NavItem onClick={() => router.push(ROUTES.FIND)}>분실물 찾기</NavItem>
       {isLoggedIn ? (
-        <Button styleType={'GHOST'} onClick={() => handleLogout()}>
+        <Button styleType="PRIMARY" onClick={() => handleLogout()} outlined>
           로그아웃
         </Button>
       ) : (
-        <Button styleType={'PRIMARY'} onClick={() => handleLogin()}>
-          로그인
+        <Button styleType="PRIMARY" onClick={() => handleLogin()}>
+          bsm 로그인
         </Button>
       )}
     </StyledNavItemsList>

--- a/src/components/common/Header/NavItemList/NavItemList.tsx
+++ b/src/components/common/Header/NavItemList/NavItemList.tsx
@@ -29,7 +29,7 @@ export const NavItemList = () => {
         폐기 물품 관리
       </NavItem>
       <Button
-        styleType={'SECONDARY'}
+        styleType="SECONDARY"
         onClick={() => router.push(ROUTES.REGISTER)}
       >
         분실물 등록 하기

--- a/src/components/common/Modal/BaseModal.tsx
+++ b/src/components/common/Modal/BaseModal.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import Flex from '@components/common/Flex/Flex';
 import { Button } from '@components/common/Button/Button';
-import type { ButtonStyleType } from '@components/common/Button/Button.type';
 import Text from '@components/common/Text/Text';
 import { IconClose } from '@/icons/src/IconClose';
 import IconCheck from '@/icons/src/IconCheck';
@@ -17,8 +16,6 @@ interface BaseModalProps {
   cancelText?: string;
   width?: string;
   children: ReactNode;
-  confirmButtonType?: ButtonStyleType;
-  cancelButtonType?: ButtonStyleType;
   titleId?: string;
 }
 

--- a/src/components/common/Modal/BaseModal.tsx
+++ b/src/components/common/Modal/BaseModal.tsx
@@ -30,8 +30,6 @@ const BaseModal = ({
   cancelText = '취소',
   width = '412px',
   children,
-  confirmButtonType = 'SECONDARY',
-  cancelButtonType = 'GHOST_SECONDARY',
   titleId,
 }: BaseModalProps) => {
   useScrollLock(isOpen);
@@ -52,7 +50,7 @@ const BaseModal = ({
           {children}
 
           <Flex justify="center" gap={8}>
-            <Button styleType={cancelButtonType} size="modal" onClick={onClose}>
+            <Button styleType="SECONDARY" size="small" onClick={onClose}>
               <IconClose width={24} height={24} />
               <Text variant="p2" color="inherit">
                 {cancelText}
@@ -61,9 +59,10 @@ const BaseModal = ({
 
             {onConfirm && (
               <Button
-                styleType={confirmButtonType}
-                size="modal"
+                styleType="SECONDARY"
+                size="small"
                 onClick={onConfirm}
+                outlined
               >
                 <IconCheck width={24} height={24} />
                 <Text variant="p2" color="inherit">

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -134,8 +134,10 @@ const PageNumber = styled.button<{ active?: boolean }>`
   justify-content: center;
   width: 32px;
   height: 32px;
-  border: ${({ active }) => (active ? `1px solid ${color.primary}` : 'none')};
-  background-color: ${({ active }) => (active ? color.primary : 'transparent')};
+  border: ${({ active }) =>
+    active ? `1px solid ${color.primary300}` : 'none'};
+  background-color: ${({ active }) =>
+    active ? color.primary300 : 'transparent'};
   color: ${({ active }) => (active ? color.white : color.gray400)};
   border-radius: ${({ active }) => (active ? '50%' : '0')};
   cursor: pointer;

--- a/src/components/common/ProductList/ProductListItem/ProductListItem.tsx
+++ b/src/components/common/ProductList/ProductListItem/ProductListItem.tsx
@@ -103,9 +103,10 @@ const ProductListItem = ({
             폐기까지 D-{daysToDisposal}
           </Text>
           <Button
-            styleType="GHOST"
+            styleType="PRIMARY"
             size="small"
             onClick={() => onExtension?.(id)}
+            outlined
           >
             기간연장
           </Button>

--- a/src/components/common/Table/Th.tsx
+++ b/src/components/common/Table/Th.tsx
@@ -43,7 +43,7 @@ const StyledTh = styled.div`
   ${font.p2}
   font-weight: 500;
   color: ${color.black};
-  background-color: ${color.primary};
+  background-color: ${color.primary300};
   border-right: 1px solid ${color.white};
   border-bottom: 1px solid ${color.white};
   &:last-child {

--- a/src/components/common/TextArea/TextArea.tsx
+++ b/src/components/common/TextArea/TextArea.tsx
@@ -54,7 +54,7 @@ const StyledTextArea = styled.textarea<StyledTextAreaProps>`
   }
 
   &:focus {
-    border-color: ${color.primary};
+    border-color: ${color.primary300};
   }
 `;
 

--- a/src/components/disposal/DisposalReasonModal/DisposalReasonModal.tsx
+++ b/src/components/disposal/DisposalReasonModal/DisposalReasonModal.tsx
@@ -145,7 +145,7 @@ const DaysInput = styled.input`
   outline: none;
 
   &:focus {
-    outline: 2px solid ${color.primary};
+    outline: 2px solid ${color.primary300};
   }
 `;
 
@@ -176,7 +176,7 @@ const StyledTextArea = styled.textarea`
 
   &:focus {
     box-shadow: 0 4px 20px rgba(135, 206, 235, 0.1);
-    outline: 2px solid ${color.primary};
+    outline: 2px solid ${color.primary300};
   }
 `;
 
@@ -188,7 +188,7 @@ const SubmitButton = styled.button`
   gap: 8px;
   width: 100%;
   height: 56px;
-  background-color: ${color.secondary};
+  background-color: ${color.secondary300};
   color: ${color.white};
   border: none;
   border-radius: 12px;

--- a/src/components/disposal/DisposalTable/DisposalTable.tsx
+++ b/src/components/disposal/DisposalTable/DisposalTable.tsx
@@ -148,7 +148,11 @@ const DisposalTable = ({ filters }: DisposalTableProps) => {
                     aria-label={`${item.name} 상세 정보 보기`}
                     onClick={() => handleItemClick(item.id)}
                   >
-                    <IconLink width={24} height={24} color={color.secondary} />
+                    <IconLink
+                      width={24}
+                      height={24}
+                      color={color.secondary300}
+                    />
                   </IconLinkButton>
                 </ItemName>
               </Td>

--- a/src/components/findDetail/FindDetailContent/FindDetailContent.tsx
+++ b/src/components/findDetail/FindDetailContent/FindDetailContent.tsx
@@ -73,20 +73,20 @@ const FindDetailContent = ({ id }: FindDetailContentProps) => {
         </Flex>
         {authority === 'ADMIN' ? (
           <Button
+            size="big"
             styleType="PRIMARY"
-            height={50}
             onClick={() => router.push(`${ROUTES.RECALL}?itemId=${id}`)}
           >
-            <Text variant="H3">회수 요청 확인하기</Text>
+            회수 요청 확인하기
           </Button>
         ) : (
           <Button
+            size="big"
             styleType="PRIMARY"
-            height={50}
             onClick={handleClaimClick}
             disabled={authority === 'TEACHER'}
           >
-            <Text variant="H3">내 물건이에요!</Text>
+            내 물건이에요!
           </Button>
         )}
       </Flex>

--- a/src/components/log/LogTable/LogTable.tsx
+++ b/src/components/log/LogTable/LogTable.tsx
@@ -110,7 +110,7 @@ const LogTable = ({ filters }: LogTableProps) => {
                   aria-label={`${item.name} 상세 정보 보기`}
                   onClick={() => handleItemClick(item.id)}
                 >
-                  <IconLink width={24} height={24} color={color.secondary} />
+                  <IconLink width={24} height={24} color={color.secondary300} />
                 </IconLinkButton>
               </ItemName>
             </Td>

--- a/src/components/main/MainRule/MainRule.tsx
+++ b/src/components/main/MainRule/MainRule.tsx
@@ -44,5 +44,5 @@ const StyledMainRule = styled.div`
   border-radius: 20px;
   gap: 20px;
   width: 100%;
-  background-color: ${color.lightblue};
+  background-color: ${color.primary100};
 `;

--- a/src/components/recall/RecallListItem/RecallListItem.tsx
+++ b/src/components/recall/RecallListItem/RecallListItem.tsx
@@ -91,6 +91,8 @@ const RecallListItem = ({
               size="small"
               onClick={() => onReject(id)}
               outlined
+              active={isRejectModalOpen}
+              width={60}
             >
               반려
             </Button>
@@ -98,6 +100,7 @@ const RecallListItem = ({
               styleType="SECONDARY"
               size="small"
               onClick={() => onApprove(id)}
+              width={60}
             >
               승인
             </Button>

--- a/src/components/recall/RecallListItem/RecallListItem.tsx
+++ b/src/components/recall/RecallListItem/RecallListItem.tsx
@@ -87,15 +87,16 @@ const RecallListItem = ({
         {recallStatus === 'PENDING' ? (
           <>
             <Button
-              styleType={isRejectModalOpen ? 'DANGER' : 'GHOST_DANGER'}
-              size="compact"
+              styleType="SECONDARY"
+              size="small"
               onClick={() => onReject(id)}
+              outlined
             >
               반려
             </Button>
             <Button
               styleType="SECONDARY"
-              size="compact"
+              size="small"
               onClick={() => onApprove(id)}
             >
               승인

--- a/src/components/recall/RecallRequestList/RecallRequestList.tsx
+++ b/src/components/recall/RecallRequestList/RecallRequestList.tsx
@@ -89,17 +89,6 @@ const RecallRequestList = ({
             />
           );
         })}
-
-        {requests.length === 0 && (
-          <Flex
-            justify="center"
-            align="center"
-            width="100%"
-            style={{ padding: '40px 0' }}
-          >
-            <Text color="gray500">회수 요청이 없습니다.</Text>
-          </Flex>
-        )}
       </Flex>
 
       <RejectModal

--- a/src/components/recall/RejectModal/RejectModal.tsx
+++ b/src/components/recall/RejectModal/RejectModal.tsx
@@ -26,13 +26,7 @@ const RejectModal = ({
   if (!item) return null;
 
   return (
-    <BaseModal
-      isOpen={isOpen}
-      onClose={onClose}
-      onConfirm={handleConfirm}
-      confirmButtonType="DANGER"
-      cancelButtonType="GHOST_DANGER"
-    >
+    <BaseModal isOpen={isOpen} onClose={onClose} onConfirm={handleConfirm}>
       <Flex direction="column" gap={40} style={{ paddingBottom: '40px' }}>
         <Flex gap={4} align="center">
           <IconStacks width={16} height={16} />

--- a/src/components/rules/Rule/CommitteeRule/DormitoryCommitteeRule/DormitoryCommitteeRule.tsx
+++ b/src/components/rules/Rule/CommitteeRule/DormitoryCommitteeRule/DormitoryCommitteeRule.tsx
@@ -25,7 +25,7 @@ const StyledDormitoryCommitteeRule = styled.div`
   flex-direction: column;
   gap: 20px;
   border-radius: 20px;
-  background-color: ${color.lightblue};
+  background-color: ${color.primary100};
 `;
 
 const Title = styled.p`

--- a/src/components/rules/Rule/CommitteeRule/LeadingCommitteeRule/LeadingCommitteeRule.tsx
+++ b/src/components/rules/Rule/CommitteeRule/LeadingCommitteeRule/LeadingCommitteeRule.tsx
@@ -25,7 +25,7 @@ const StyledLeadingCommitteeRule = styled.div`
   flex-direction: column;
   gap: 20px;
   border-radius: 20px;
-  background-color: ${color.lightgreen};
+  background-color: ${color.secondary100};
 `;
 const Title = styled.p`
   ${font.H2}

--- a/src/components/rules/Rule/PenaltyRule/PenaltyRule.tsx
+++ b/src/components/rules/Rule/PenaltyRule/PenaltyRule.tsx
@@ -116,18 +116,18 @@ const PenaltyRule = ({ id }: PenaltyRuleProps) => {
           <Th
             width={240}
             height={36}
-            backgroundColor={color.primary}
+            backgroundColor={color.primary300}
             borderTopLeftRadius={10}
           >
             구분
           </Th>
-          <Th width={'100%'} height={36} backgroundColor={color.primary}>
+          <Th width={'100%'} height={36} backgroundColor={color.primary300}>
             내용
           </Th>
           <Th
             width={80}
             height={36}
-            backgroundColor={color.primary}
+            backgroundColor={color.primary300}
             borderTopRightRadius={10}
           >
             점수
@@ -165,7 +165,7 @@ const StyledPenaltyRule = styled.div`
   gap: 20px;
   padding: 20px 30px;
   border-radius: 20px;
-  background-color: ${color.lightblue};
+  background-color: ${color.primary100};
 `;
 
 const Title = styled.p`

--- a/src/components/rules/Rule/PenaltyRule/PenaltyRule.tsx
+++ b/src/components/rules/Rule/PenaltyRule/PenaltyRule.tsx
@@ -121,7 +121,7 @@ const PenaltyRule = ({ id }: PenaltyRuleProps) => {
           >
             구분
           </Th>
-          <Th width={'100%'} height={36} backgroundColor={color.primary300}>
+          <Th width="100%" height={36} backgroundColor={color.primary300}>
             내용
           </Th>
           <Th
@@ -138,7 +138,7 @@ const PenaltyRule = ({ id }: PenaltyRuleProps) => {
             <Td width={240} height={44}>
               {item.category}
             </Td>
-            <Td width={'100%'} height={44}>
+            <Td width="100%" height={44}>
               {item.content}
               {item.isImportant && <Asterisk>*</Asterisk>}
             </Td>

--- a/src/components/rules/Rule/RewardRule/RewardRule.tsx
+++ b/src/components/rules/Rule/RewardRule/RewardRule.tsx
@@ -106,7 +106,7 @@ const StyledRewardRule = styled.div`
   padding: 20px 30px;
   border-radius: 20px;
   gap: 20px;
-  background-color: ${color.primary100};
+  background-color: ${color.secondary100};
 `;
 
 const Title = styled.p`

--- a/src/components/rules/Rule/RewardRule/RewardRule.tsx
+++ b/src/components/rules/Rule/RewardRule/RewardRule.tsx
@@ -67,7 +67,7 @@ const RewardRule = ({ id }: RewardRuleProps) => {
           >
             구분
           </Th>
-          <Th width={'100%'} height={36} backgroundColor={color.secondary300}>
+          <Th width="100%" height={36} backgroundColor={color.secondary300}>
             내용
           </Th>
           <Th
@@ -84,7 +84,7 @@ const RewardRule = ({ id }: RewardRuleProps) => {
             <Td width={240} height={44}>
               {item.category}
             </Td>
-            <Td width={'100%'} height={44}>
+            <Td width="100%" height={44}>
               {item.content}
             </Td>
             <Td width={80} height={44}>

--- a/src/components/rules/Rule/RewardRule/RewardRule.tsx
+++ b/src/components/rules/Rule/RewardRule/RewardRule.tsx
@@ -62,18 +62,18 @@ const RewardRule = ({ id }: RewardRuleProps) => {
           <Th
             width={240}
             height={36}
-            backgroundColor={color.secondary}
+            backgroundColor={color.secondary300}
             borderTopLeftRadius={10}
           >
             구분
           </Th>
-          <Th width={'100%'} height={36} backgroundColor={color.secondary}>
+          <Th width={'100%'} height={36} backgroundColor={color.secondary300}>
             내용
           </Th>
           <Th
             width={80}
             height={36}
-            backgroundColor={color.secondary}
+            backgroundColor={color.secondary300}
             borderTopRightRadius={10}
           >
             점수
@@ -106,7 +106,7 @@ const StyledRewardRule = styled.div`
   padding: 20px 30px;
   border-radius: 20px;
   gap: 20px;
-  background-color: ${color.lightgreen};
+  background-color: ${color.primary100};
 `;
 
 const Title = styled.p`

--- a/src/components/rules/Rule/StandardApplyingPoint/StandardApplyingPoint.tsx
+++ b/src/components/rules/Rule/StandardApplyingPoint/StandardApplyingPoint.tsx
@@ -51,7 +51,7 @@ const StyledStandardApplyingPoint = styled.div`
   padding: 20px 30px;
   border-radius: 20px;
   gap: 20px;
-  background-color: ${color.lightblue};
+  background-color: ${color.primary100};
 `;
 
 const Title = styled.p`

--- a/src/components/rules/Rule/StandardApplyingPoint/StandardApplyingPoint.tsx
+++ b/src/components/rules/Rule/StandardApplyingPoint/StandardApplyingPoint.tsx
@@ -11,7 +11,7 @@ const StandardApplyingPoint = ({ id }: StandardApplyingPointProps) => {
     <StyledStandardApplyingPoint id={id}>
       <Title>상벌점제 적용 기준</Title>
       <Description>
-        <Bold>상점 1점</Bold>은 <Bold>벌점 1점</Bold>을 상쇄 가능하다.{' '}
+        <Bold>상점 1점</Bold>은 <Bold>벌점 1점</Bold>을 상쇄 가능하다.
       </Description>
       <TextBox>
         <Description>

--- a/src/components/teacher/DashboardRoute/DashboardRouteCard/DashboardRouteCard.tsx
+++ b/src/components/teacher/DashboardRoute/DashboardRouteCard/DashboardRouteCard.tsx
@@ -50,7 +50,7 @@ const StyledDashboardRouteCard = styled.div<{ isPrimary: boolean }>`
     isPrimary &&
     `
      height: 100%;
-     background-color: ${color.primary};
+     background-color: ${color.primary300};
      width: 30%; 
      color: ${color.white};
      border:none;

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -2,11 +2,17 @@ const color = {
   white: '#FFFFFF',
   black: '#000000',
 
-  primary: '#87CEEB',
-  secondary: '#50C878',
+  primary100: '#F3FAFD',
+  primary200: '#CFEBF7',
+  primary300: '#87CEEB',
+  primary400: '#63C0E5',
+  primary500: '#3FB1DF',
 
-  lightblue: '#EDF8FC',
-  lightgreen: '#E5F7EB',
+  secondary100: '#EDF9F1',
+  secondary200: '#B9E9C9',
+  secondary300: '#50C878',
+  secondary400: '#1CB850',
+  secondary500: '#00A727',
 
   gray100: '#F6F6F6',
   gray200: '#DEDEDE',


### PR DESCRIPTION
## 📄 Summary

>  버튼 재스타일링 & color primary, secondary 100-500 추가

<br>

## 🔨 Tasks

-  버튼 재스타일링
-  color primary, secondary 100-500 추가

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 버튼에 아이콘 지원, 비활성화 처리 및 신규 큰 사이즈 추가

* **스타일**
  * 전역 색상 팔레트 세분화 및 다수 컴포넌트의 색상·포커스·호버 스타일 조정
  * 내비게이션 로그인 버튼 라벨을 "bsm 로그인"으로 변경
  * 일부 버튼 및 표지·카드의 기본 색상·크기/텍스트 표시 방식 조정

* **리팩터**
  * 버튼 스타일 결정 방식 개선

* **기타**
  * 모달 기본 버튼 스타일 업데이트 및 빈 회수 요청 화면 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->