### PR TITLE
fix(user): 불필요한 search API 중복 호출 제거

### DIFF
--- a/src/components/findDetail/ClaimModal/ClaimModal.tsx
+++ b/src/components/findDetail/ClaimModal/ClaimModal.tsx
@@ -13,40 +13,16 @@ import DateSelector from '@components/common/DateSelector/DateSelector';
 import { useItemClaimMutation } from '@services/item/mutations';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { useQueryClient } from '@tanstack/react-query';
-import { GetItemListRes } from '@/types/item/response';
-import { Item } from '@/types/item/client';
 
 interface ClaimModalProps {
   id: number;
   isOpen: boolean;
   onClose: () => void;
+  disposalDate?: string;
 }
 
-const ClaimModal = ({ id, isOpen, onClose }: ClaimModalProps) => {
+const ClaimModal = ({ id, isOpen, onClose, disposalDate }: ClaimModalProps) => {
   const [visitDate, setVisitDate] = useState<Date | null>(null);
-  const queryClient = useQueryClient();
-
-  const findItemInCache = (): Item | null => {
-    const cacheData = queryClient.getQueriesData({
-      queryKey: ['item', 'list'],
-    });
-
-    for (const [, data] of cacheData) {
-      if (data && typeof data === 'object' && 'content' in data) {
-        const itemListData = data as GetItemListRes;
-        if (Array.isArray(itemListData.content)) {
-          const item = itemListData.content.find(
-            (item: Item) => item.id === Number(id)
-          );
-          if (item) return item;
-        }
-      }
-    }
-    return null;
-  };
-
-  const itemData = findItemInCache();
 
   const isWeekday = (date: Date) => {
     const day = date.getDay();
@@ -57,9 +33,7 @@ const ClaimModal = ({ id, isOpen, onClose }: ClaimModalProps) => {
 
   useScrollLock(isOpen);
 
-  const maxDate = itemData?.disposalDate
-    ? new Date(itemData.disposalDate)
-    : undefined;
+  const maxDate = disposalDate ? new Date(disposalDate) : undefined;
 
   const handleSubmit = () => {
     if (!visitDate || !maxDate || visitDate > maxDate) {

--- a/src/components/findDetail/ClaimModal/ClaimModal.tsx
+++ b/src/components/findDetail/ClaimModal/ClaimModal.tsx
@@ -11,9 +11,11 @@ import { useScrollLock } from '@hooks/useScrollLock';
 import { Button } from '@components/common/Button/Button';
 import DateSelector from '@components/common/DateSelector/DateSelector';
 import { useItemClaimMutation } from '@services/item/mutations';
-import { useItemListQuery } from '@services/item/queries';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { useQueryClient } from '@tanstack/react-query';
+import { GetItemListRes } from '@/types/item/response';
+import { Item } from '@/types/item/client';
 
 interface ClaimModalProps {
   id: number;
@@ -23,12 +25,28 @@ interface ClaimModalProps {
 
 const ClaimModal = ({ id, isOpen, onClose }: ClaimModalProps) => {
   const [visitDate, setVisitDate] = useState<Date | null>(null);
+  const queryClient = useQueryClient();
 
-  const { data: itemListData } = useItemListQuery({});
+  const findItemInCache = (): Item | null => {
+    const cacheData = queryClient.getQueriesData({
+      queryKey: ['item', 'list'],
+    });
 
-  const itemData = itemListData?.content?.find(
-    (item) => item.id === Number(id)
-  );
+    for (const [, data] of cacheData) {
+      if (data && typeof data === 'object' && 'content' in data) {
+        const itemListData = data as GetItemListRes;
+        if (Array.isArray(itemListData.content)) {
+          const item = itemListData.content.find(
+            (item: Item) => item.id === Number(id)
+          );
+          if (item) return item;
+        }
+      }
+    }
+    return null;
+  };
+
+  const itemData = findItemInCache();
 
   const isWeekday = (date: Date) => {
     const day = date.getDay();

--- a/src/components/findDetail/FindDetailContent/FindDetailContent.tsx
+++ b/src/components/findDetail/FindDetailContent/FindDetailContent.tsx
@@ -44,7 +44,12 @@ const FindDetailContent = ({ id }: FindDetailContentProps) => {
       return;
     }
     overlay.open(({ isOpen, close }) => (
-      <ClaimModal id={id} isOpen={isOpen} onClose={close} />
+      <ClaimModal
+        id={id}
+        isOpen={isOpen}
+        onClose={close}
+        disposalDate={itemData.disposalDate}
+      />
     ));
   };
 


### PR DESCRIPTION
## 📄 Summary

> 불필요한 search API 중복 호출 제거

<br>

## 🔨 Tasks

- ClaimModal에서 TanStack Query 캐시 데이터 활용
- Find 페이지에서 조회한 아이템 목록 재사용으로 성능 개선

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 클레임 모달의 날짜 처리 로직을 정리했습니다. 외부에서 전달되는 폐기일(disposalDate)을 우선 사용해 제출 가능한 최대 날짜를 결정합니다.
  * 상세 보기에서 모달로 폐기일을 전달하도록 변경해 날짜 제한이 일관되게 적용됩니다.
  * 기존 제출 흐름과 검증은 유지되며, 불필요한 내부 조회를 제거해 성능과 예측 가능성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->