### PR TITLE
fix(user): 유저에서 폐기 물품 자세히보기 안뜨도록 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,7 +81,7 @@ const MainPage = () => {
       <SmallProductList
         title="폐기 직전인 분실물"
         productList={disposalProductListData?.content || []}
-        href={ROUTES.ADMIN_DISPOSAL}
+        href={isManager ? ROUTES.ADMIN_DISPOSAL : undefined}
       />
     </StyledMainPage>
   );

--- a/src/components/common/ProductList/SmallProductList.tsx
+++ b/src/components/common/ProductList/SmallProductList.tsx
@@ -20,13 +20,19 @@ const SmallProductList = ({ title, productList, href }: ProductListProps) => {
         )}
       </Flex>
       <Flex width="100%" gap={20} style={{ overflowX: 'auto' }}>
-        {productList?.map((product) => (
-          <ProductListItem
-            key={`product-${product.id}`}
-            product={product}
-            size="small"
-          />
-        ))}
+        {productList.length > 0 ? (
+          productList.map((product) => (
+            <ProductListItem
+              key={`product-${product.id}`}
+              product={product}
+              size="small"
+            />
+          ))
+        ) : (
+          <Text width="100%" textAlign="center" color={color.gray500}>
+            분실물 목록이 없습니다.
+          </Text>
+        )}
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
## 📄 Summary

> 유저에서 폐기 물품 자세히보기 안뜨도록 수정

<br>

## 🔨 Tasks

- 유저에서 폐기 물품 자세히보기 안뜨도록 수정

<br>

## 🙋🏻 More


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 분실물 목록이 없을 때 안내 메시지를 표시하도록 개선했습니다.

* **개선 사항**
  * 권한에 따른 특정 섹션의 접근 제한을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->