### PR TITLE
feat(auth): JWT 이름/학번 클레임 프론트 반영

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -47,6 +47,8 @@ const AuthCallbackPage = () => {
           {
             email: userEmail,
             authority,
+            name: payload.name || '',
+            studentCode: payload.studentCode ?? null,
           },
           token
         );

--- a/src/components/layout/Header/NavItemList/NavItemList.tsx
+++ b/src/components/layout/Header/NavItemList/NavItemList.tsx
@@ -64,7 +64,7 @@ export const NavItemList = () => {
   };
 
   const getUserDisplayName = () => {
-    if (studentCode && name) {
+    if (studentCode != null && name) {
       return `${studentCode} ${name}`;
     }
 

--- a/src/components/layout/Header/NavItemList/NavItemList.tsx
+++ b/src/components/layout/Header/NavItemList/NavItemList.tsx
@@ -11,8 +11,15 @@ import font from '@styles/font';
 
 export const NavItemList = () => {
   const router = useRouter();
-  const { isLoggedIn, logout, email, authority, isInitialized } =
-    useAuthStore();
+  const {
+    isLoggedIn,
+    logout,
+    email,
+    authority,
+    isInitialized,
+    name,
+    studentCode,
+  } = useAuthStore();
   const [showDropdown, setShowDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -57,6 +64,14 @@ export const NavItemList = () => {
   };
 
   const getUserDisplayName = () => {
+    if (studentCode && name) {
+      return `${studentCode} ${name}`;
+    }
+
+    if (name) {
+      return name;
+    }
+
     return email.split('@')[0];
   };
 

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -21,6 +21,8 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       email: '',
       authority: 'USER',
+      name: '',
+      studentCode: null,
       isLoggedIn: false,
       isInitialized: false,
       isLogoutRedirecting: false,
@@ -46,6 +48,8 @@ export const useAuthStore = create<AuthState>()(
           set({
             email: '',
             authority: 'USER',
+            name: '',
+            studentCode: null,
             isLoggedIn: false,
             accessToken: null,
           });
@@ -67,6 +71,8 @@ export const useAuthStore = create<AuthState>()(
       partialize: (state) => ({
         email: state.email,
         authority: state.authority,
+        name: state.name,
+        studentCode: state.studentCode,
         isLoggedIn: state.isLoggedIn,
         accessToken: state.accessToken,
       }),

--- a/src/types/user/client.ts
+++ b/src/types/user/client.ts
@@ -3,4 +3,6 @@ export type UserAuthority = 'ADMIN' | 'TEACHER' | 'USER';
 export interface User {
   email: string;
   authority: UserAuthority;
+  name: string;
+  studentCode: number | null;
 }

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -3,6 +3,8 @@ interface JwtPayload {
   email: string;
   role: string;
   type: string;
+  name?: string;
+  studentCode?: number;
   iat: number;
   exp: number;
 }


### PR DESCRIPTION
## 📄 Summary

> JWT 학번/이름 클레임을 프론트에 반영했습니다.

<br>

## 🔨 Tasks

- JWT payload 타입에 `name`, `studentCode` 추가
- 로그인 콜백에서 `name`, `studentCode`를 auth store에 저장하도록 수정
- auth store persist 대상에 이름/학번 포함
- 헤더 사용자 표시를 `학번 이름` 우선으로 변경
- 값이 없을 경우 이름, 이메일 앞부분 순으로 fallback 처리

<br>

## 🙋🏻 More
